### PR TITLE
Update scripts.js

### DIFF
--- a/src/tasks/scripts.js
+++ b/src/tasks/scripts.js
@@ -36,7 +36,8 @@ class ScriptsTask extends Task {
                     useBuiltIns: "entry",
                     corejs: 3,
                 }]
-            ]
+            ],
+            global: true,
         });
 
         const bundle = () => b.bundle()


### PR DESCRIPTION
Behebt den Fehler:
`SyntaxError: 'import' and 'export' may appear only with 'sourceType: module'

Gefunden auf
https://stackoverflow.com/questions/40029113/syntaxerror-import-and-export-may-appear-only-with-sourcetype-module-g/56608843#56608843